### PR TITLE
Add numpad and tmux layout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# As there is (still) no Travis Lua language support, we use the fine
+# https://github.com/mpeterv/hererocks local environment build to set
+# up a local Lua/luarocks/packages environment.
+language: python
+sudo: false
+
+branches:
+  only:
+    - /.*/
+
+before_install:
+  - ./env.sh # installs the local environment.
+
+script:
+  - ./env.sh busted # runs all tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
   only:
     - /.*/
 
-before_install:
+install:
   - ./env.sh # installs the local environment.
 
 script:

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ We start with the probably indispensable media player controls keyboard layout.
 ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
 ┊ 10 ┊  ┊  7 ┊  ┊  4 ┊  ┊  1 ┊
 └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
-                  ⏹️️
+space             ⏹️️
 ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
 ┊  9 ┊  ┊  6 ┊  ┊  3 ┊  ┊  0 ┊
 └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
-          ◀️◀️      ▮▶      ▶▶
+ESC       ◀️◀️      ▮▶      ▶▶
 ```
 
 ### Debug Go in VisualStudio Code
@@ -112,9 +112,38 @@ Debug Go programs and packages in VisualStudio Code with its Go extension.
 - DEBUG opens/shows debug panel.
 - CLOSE PANEL ... closes the output/debug panel.
 
-### Kdenlive Video Editor
+### Numpad
 
-_coming soon..._
+Regular layout
+```text
+┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
+┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
+└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
+           9       8       7
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+   0       6       5       4
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+ enter     3       2       1
+```
+Shirt layout
+```text
+┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
+┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
+└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
+           +       -       =
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+   .       /       %       $
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+   ,   backspace delete   ESC
+```
 
 ### SHIFT Overlay
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,38 @@ Shirt layout
    ,   backspace delete   ESC
 ```
 
+### Tmux
+
+Regular layout
+```text
+┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
+┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
+└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
+        split v  move l move r
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+split h new window      move u
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+exit    cycle p cycle n move d
+```
+Shirt layout (...coming soon)
+```text
+┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
+┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
+└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
+
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+
+╔════╗  ╔════╗  ╔════╗  ╔════╗
+║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
+╚════╝  ╚════╝  ╚════╝  ╚════╝
+```
+
 ### SHIFT Overlay
 
 This layout provides a SHIFT key. Only when pressed and held, two additional

--- a/sdcard/keys.lua
+++ b/sdcard/keys.lua
@@ -3,5 +3,6 @@ require "layouts/shift" -- for cycling between layouts.
 require "layouts/media-player" -- indispensable media player controls.
 --require "layouts/vsc-golang" -- debugging Go programs in VisualStudio Code.
 --require "layouts/kdenlive" -- editing video using Kdenlive.
-require "layouts/numpad" -- numpad with shift layout
+require "layouts/numpad" -- numpad with shift layout.
+require "layouts/tmux" -- tmux layout using ` as prefix
 require "layouts/empty" -- empty, do-nothing layout.

--- a/sdcard/keys.lua
+++ b/sdcard/keys.lua
@@ -5,4 +5,5 @@ require "layouts/media-player" -- indispensable media player controls.
 --require "layouts/kdenlive" -- editing video using Kdenlive.
 require "layouts/numpad" -- numpad with shift layout.
 require "layouts/tmux" -- tmux layout using ` as prefix
+require "layouts/i3" -- i3 layout using super as prefix
 require "layouts/empty" -- empty, do-nothing layout.

--- a/sdcard/keys.lua
+++ b/sdcard/keys.lua
@@ -1,6 +1,7 @@
 require "keybow"
 require "layouts/shift" -- for cycling between layouts.
 require "layouts/media-player" -- indispensable media player controls.
-require "layouts/vsc-golang" -- debugging Go programs in VisualStudio Code.
-require "layouts/kdenlive" -- editing video using Kdenlive.
+--require "layouts/vsc-golang" -- debugging Go programs in VisualStudio Code.
+--require "layouts/kdenlive" -- editing video using Kdenlive.
+require "layouts/numpad" -- numpad with shift layout
 require "layouts/empty" -- empty, do-nothing layout.

--- a/sdcard/layouts/i3.lua
+++ b/sdcard/layouts/i3.lua
@@ -1,0 +1,67 @@
+local i3 = _G.i3 or {}
+local mb = require("snippets/multibow")
+--[[
+The Keybow layout is as follows when in landscape orientation, with the USB
+cable going off "northwards":
+
+              ┋┋
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A1 ┊  ┊ B1 ┊  ┊ C1 ┊  ┊ D1 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A2 ┊  ┊ B2 ┊  ┊ C2 ┊  ┊ D2 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A3 ┊  ┊ B3 ┊  ┊ C3 ┊  ┊ D3 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+
+]]--
+-- Instead of using 0 to 11, i renamed them to row/colums
+i3.A1 = i3.A1 or 11
+i3.A2 = i3.A2 or 10
+i3.A3 = i3.A3 or 9
+
+i3.B1 = i3.B1 or 8
+i3.B2 = i3.B2 or 7
+i3.B3 = i3.B3 or 6
+
+i3.C1 = i3.C1 or 5
+i3.C2 = i3.C2 or 4
+i3.C3 = i3.C3 or 3
+
+i3.D1 = i3.D1 or 2
+i3.D2 = i3.D2 or 1
+i3.D3 = i3.D3 or 0
+
+function i3.command(cmd)
+    mb.tap(keybow.SUPER)
+    keybow.sleep(50)
+    mb.tap(cmd)
+end
+
+function i3.exit()
+    keybow.text("exit")
+    keybow.tap_enter()
+end
+
+i3.keymap = {
+    name="i3",
+    [i3.A2] = { c={r=0, g=1, b=1}, press=function(_) i3.command("v") end},
+    [i3.B1] = { c={r=0, g=1, b=1}, press=function(_) i3.command("b") end},
+    [i3.B2] = { c={r=0, g=0.5, b=1}, press=function(_) i3.command("f") end},
+
+    [i3.C1] = { c={r=1, g=1, b=0}, press=function(_) i3.command("h") end},
+    [i3.D1] = { c={r=1, g=1, b=0}, press=function(_) i3.command("l") end},
+
+    [i3.D2] = { c={r=1, g=0, b=1}, press=function(_) i3.command("k") end},
+    [i3.D3] = { c={r=1, g=0, b=1}, press=function(_) i3.command("j") end},
+
+    [i3.B3] = { c={r=0.5, g=1, b=0.5}, press=function(_) i3.command("p") end},
+    [i3.C3] = { c={r=0.5, g=1, b=0.5}, press=function(_) i3.command("n") end},
+
+    [i3.A3] = { c={r=1, g=0, b=0}, press=function(_) i3.exit() end},
+
+}
+
+mb.register_keymap(i3.keymap)
+return i3

--- a/sdcard/layouts/media-player.lua
+++ b/sdcard/layouts/media-player.lua
@@ -66,6 +66,11 @@ mplay.keymap = {
     [mplay.KEY_MUTE] = { c={r=0.5, g=0.1, b=0.1}, press=function() mb.tap(keybow.MEDIA_MUTE) end},
     [mplay.KEY_VOLDN] = { c={r=0.5, g=0.5, b=0.5}, press=function() mb.tap(keybow.MEDIA_VOLUMEDOWN) end},
     [mplay.KEY_VOLUP] = { c={r=1, g=1, b=1}, press=function() mb.tap(keybow.MEDIA_VOLUMEUP) end},
+
+    [10] =  { c={r=0, g=1, b=0}, press=function() mb.tap(keybow.ESC) end}, --exit fullscreen on most players
+    [9] =  { c={r=0, g=1, b=0}, press=function() mb.tap(keybow.SPACE) end}, --pause on web eg. plex
+
+
 }
 mb.register_keymap(mplay.keymap)
 

--- a/sdcard/layouts/numpad.lua
+++ b/sdcard/layouts/numpad.lua
@@ -1,4 +1,4 @@
-local km = _G.km or {}
+local mp = _G.mp or {}
 local mb = require("snippets/multibow")
 
 --[[
@@ -18,65 +18,65 @@ cable going off "northwards":
 
 ]]--
 -- Instead of using 0 to 11, i renamed them to row/colums
-km.A1 = km.A1 or 11
-km.A2 = km.A2 or 10
-km.A3 = km.A3 or 9
+mp.A1 = mp.A1 or 11
+mp.A2 = mp.A2 or 10
+mp.A3 = mp.A3 or 9
 
-km.B1 = km.B1 or 8
-km.B2 = km.B2 or 7
-km.B3 = km.B3 or 6
+mp.B1 = mp.B1 or 8
+mp.B2 = mp.B2 or 7
+mp.B3 = mp.B3 or 6
 
-km.C1 = km.C1 or 5
-km.C2 = km.C2 or 4
-km.C3 = km.C3 or 3
+mp.C1 = mp.C1 or 5
+mp.C2 = mp.C2 or 4
+mp.C3 = mp.C3 or 3
 
-km.D1 = km.D1 or 2
-km.D2 = km.D2 or 1
-km.D3 = km.D3 or 0
+mp.D1 = mp.D1 or 2
+mp.D2 = mp.D2 or 1
+mp.D3 = mp.D3 or 0
 
 -- Setup shift key
-function km.unshift(_)
-    mb.activate_keymap(km.keymap.name)
+function mp.unshift(_)
+    mb.activate_keymap(mp.keymap.name)
 end
 
 -- The keymap layout...
-km.keymap = {
-    name="numpad",
+mp.keymap = {
+    name="mp",
     -- A1 is the shift key, so we skip that
-    [km.A2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("0") end},
-    [km.A3] = { c={r=0, g=0, b=1}, press=function() mb.tap(keybow.ENTER) end},
-    [km.B1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("9") end},
-    [km.B2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("6") end},
-    [km.B3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("3") end},
-    [km.C1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("8") end},
-    [km.C2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("5") end},
-    [km.C3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("2") end},
-    [km.D1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("7") end},
-    [km.D2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("4") end},
-    [km.D3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("1") end},
+    [mp.A2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("0") end},
+    [mp.A3] = { c={r=0, g=0, b=1}, press=function() mb.tap(keybow.ENTER) end},
+    [mp.B1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("9") end},
+    [mp.B2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("6") end},
+    [mp.B3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("3") end},
+    [mp.C1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("8") end},
+    [mp.C2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("5") end},
+    [mp.C3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("2") end},
+    [mp.D1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("7") end},
+    [mp.D2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("4") end},
+    [mp.D3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("1") end},
 }
 
-km.keymap_shifted = {
-    name="numpad-shifted",
+mp.keymap_shifted = {
+    name="mp-shifted",
     secondary=true,
 
-    [km.A2] = { c={r=0, g=1, b=0}, press=function() mb.tap(".") end},
-    [km.A3] = { c={r=0, g=1, b=0}, press=function() mb.tap(",") end},
-    [km.B1] = { c={r=0, g=1, b=1}, press=function() mb.tap("+") end},
-    [km.C1] = { c={r=0, g=1, b=1}, press=function() mb.tap("-") end},
-    [km.D1] = { c={r=0, g=1, b=1}, press=function() mb.tap("=") end},
-    [km.B2] = { c={r=0, g=1, b=1}, press=function() mb.tap("/") end},
-    [km.C2] = { c={r=0, g=1, b=1}, press=function() mb.tap("%") end},
-    [km.D2] = { c={r=1, g=1, b=0}, press=function() mb.tap("$") end},
-    [km.B3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.BACKSPACE) end},
-    [km.C3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.DELETE) end},
-    --[km.D3] = { c={r=0.5, g=0.5, b=1}, press=function() mb.tap(keybow.ESC) end},
+    [mp.A2] = { c={r=0, g=1, b=0}, press=function() mb.tap(".") end},
+    [mp.A3] = { c={r=0, g=1, b=0}, press=function() mb.tap(",") end},
+    [mp.B1] = { c={r=0, g=1, b=1}, press=function() mb.tap("+") end},
+    [mp.C1] = { c={r=0, g=1, b=1}, press=function() mb.tap("-") end},
+    [mp.D1] = { c={r=0, g=1, b=1}, press=function() mb.tap("=") end},
+    [mp.B2] = { c={r=0, g=1, b=1}, press=function() mb.tap("/") end},
+    [mp.C2] = { c={r=0, g=1, b=1}, press=function() mb.tap("%") end},
+    [mp.D2] = { c={r=1, g=1, b=0}, press=function() mb.tap("$") end},
+    [mp.B3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.BACKSPACE) end},
+    [mp.C3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.DELETE) end},
+    --[mp.D3] = { c={r=0.5, g=0.5, b=1}, press=function() mb.tap(keybow.ESC) end},
 
-    [-1] = {release=km.unshift},
+    [-1] = {release=mp.unshift},
 }
-km.keymap.shift_to = km.keymap_shifted
-km.keymap_shifted.shift_to = km.keymap
+mp.keymap.shift_to = mp.keymap_shifted
+mp.keymap_shifted.shift_to = mp.keymap
 
-mb.register_keymap(km.keymap)
-mb.register_keymap(km.keymap_shifted)
-
+mb.register_keymap(mp.keymap)
+mb.register_keymap(mp.keymap_shifted)
+return mp

--- a/sdcard/layouts/numpad.lua
+++ b/sdcard/layouts/numpad.lua
@@ -45,15 +45,15 @@ mp.keymap = {
     -- A1 is the shift key, so we skip that
     [mp.A2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("0") end},
     [mp.A3] = { c={r=0, g=0, b=1}, press=function() mb.tap(keybow.ENTER) end},
-    [mp.B1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("9") end},
-    [mp.B2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("6") end},
-    [mp.B3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("3") end},
+    [mp.B1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("7") end},
+    [mp.B2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("4") end},
+    [mp.B3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("1") end},
     [mp.C1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("8") end},
     [mp.C2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("5") end},
     [mp.C3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("2") end},
-    [mp.D1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("7") end},
-    [mp.D2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("4") end},
-    [mp.D3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("1") end},
+    [mp.D1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("9") end},
+    [mp.D2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("6") end},
+    [mp.D3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("3") end},
 }
 
 mp.keymap_shifted = {

--- a/sdcard/layouts/numpad.lua
+++ b/sdcard/layouts/numpad.lua
@@ -1,0 +1,82 @@
+local km = _G.km or {}
+local mb = require("snippets/multibow")
+
+--[[
+The Keybow layout is as follows when in landscape orientation, with the USB
+cable going off "northwards":
+
+              ┋┋
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A1 ┊  ┊ B1 ┊  ┊ C1 ┊  ┊ D1 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A2 ┊  ┊ B2 ┊  ┊ C2 ┊  ┊ D2 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A3 ┊  ┊ B3 ┊  ┊ C3 ┊  ┊ D3 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+
+]]--
+-- Instead of using 0 to 11, i renamed them to row/colums
+km.A1 = km.A1 or 11
+km.A2 = km.A2 or 10
+km.A3 = km.A3 or 9
+
+km.B1 = km.B1 or 8
+km.B2 = km.B2 or 7
+km.B3 = km.B3 or 6
+
+km.C1 = km.C1 or 5
+km.C2 = km.C2 or 4
+km.C3 = km.C3 or 3
+
+km.D1 = km.D1 or 2
+km.D2 = km.D2 or 1
+km.D3 = km.D3 or 0
+
+-- Setup shift key
+function km.unshift(_)
+    mb.activate_keymap(km.keymap.name)
+end
+
+-- The keymap layout...
+km.keymap = {
+    name="numpad",
+    -- A1 is the shift key, so we skip that
+    [km.A2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("0") end},
+    [km.A3] = { c={r=0, g=0, b=1}, press=function() mb.tap(keybow.ENTER) end},
+    [km.B1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("9") end},
+    [km.B2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("6") end},
+    [km.B3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("3") end},
+    [km.C1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("8") end},
+    [km.C2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("5") end},
+    [km.C3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("2") end},
+    [km.D1] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("7") end},
+    [km.D2] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("4") end},
+    [km.D3] = { c={r=0, g=1, b=0.5}, press=function() mb.tap("1") end},
+}
+
+km.keymap_shifted = {
+    name="numpad-shifted",
+    secondary=true,
+
+    [km.A2] = { c={r=0, g=1, b=0}, press=function() mb.tap(".") end},
+    [km.A3] = { c={r=0, g=1, b=0}, press=function() mb.tap(",") end},
+    [km.B1] = { c={r=0, g=1, b=1}, press=function() mb.tap("+") end},
+    [km.C1] = { c={r=0, g=1, b=1}, press=function() mb.tap("-") end},
+    [km.D1] = { c={r=0, g=1, b=1}, press=function() mb.tap("=") end},
+    [km.B2] = { c={r=0, g=1, b=1}, press=function() mb.tap("/") end},
+    [km.C2] = { c={r=0, g=1, b=1}, press=function() mb.tap("%") end},
+    [km.D2] = { c={r=1, g=1, b=0}, press=function() mb.tap("$") end},
+    [km.B3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.BACKSPACE) end},
+    [km.C3] = { c={r=1, g=0, b=0}, press=function() mb.tap(keybow.DELETE) end},
+    --[km.D3] = { c={r=0.5, g=0.5, b=1}, press=function() mb.tap(keybow.ESC) end},
+
+    [-1] = {release=km.unshift},
+}
+km.keymap.shift_to = km.keymap_shifted
+km.keymap_shifted.shift_to = km.keymap
+
+mb.register_keymap(km.keymap)
+mb.register_keymap(km.keymap_shifted)
+

--- a/sdcard/layouts/tmux.lua
+++ b/sdcard/layouts/tmux.lua
@@ -1,0 +1,45 @@
+local tm = {}
+local mb = require("snippets/multibow")
+--[[
+The Keybow layout is as follows when in landscape orientation, with the USB
+cable going off "northwards":
+
+              ┋┋
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A1 ┊  ┊ B1 ┊  ┊ C1 ┊  ┊ D1 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A2 ┊  ┊ B2 ┊  ┊ C2 ┊  ┊ D2 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐  ┌╌╌╌╌┐
+┊ A3 ┊  ┊ B3 ┊  ┊ C3 ┊  ┊ D3 ┊
+└╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘  └╌╌╌╌┘
+
+]]--
+-- Instead of using 0 to 11, i renamed them to row/colums
+tm.A1 = tm.A1 or 11
+tm.A2 = tm.A2 or 10
+tm.A3 = tm.A3 or 9
+
+tm.B1 = tm.B1 or 8
+tm.B2 = tm.B2 or 7
+tm.B3 = tm.B3 or 6
+
+tm.C1 = tm.C1 or 5
+tm.C2 = tm.C2 or 4
+tm.C3 = tm.C3 or 3
+
+tm.D1 = tm.D1 or 2
+tm.D2 = tm.D2 or 1
+tm.D3 = tm.D3 or 0
+
+tm.keymap = {
+    name="tmux",
+    [8] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "b") end},
+    [10] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "v") end},
+    [7] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "c") end},
+
+}
+
+mb.register_keymap(tm.keymap)
+return tm

--- a/sdcard/layouts/tmux.lua
+++ b/sdcard/layouts/tmux.lua
@@ -1,4 +1,4 @@
-local tm = {}
+local tm = _G.tm or {}
 local mb = require("snippets/multibow")
 --[[
 The Keybow layout is as follows when in landscape orientation, with the USB
@@ -33,11 +33,33 @@ tm.D1 = tm.D1 or 2
 tm.D2 = tm.D2 or 1
 tm.D3 = tm.D3 or 0
 
+function tm.command(cmd)
+    mb.tap("`")
+    keybow.sleep(50)
+    mb.tap(cmd)
+end
+
+function tm.exit()
+    keybow.text("exit")
+    keybow.tap_enter()
+end
+
 tm.keymap = {
     name="tmux",
-    [8] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "b") end},
-    [10] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "v") end},
-    [7] = { c={r=0, g=1, b=1}, press=function() mb.tap("`", "c") end},
+    [tm.A2] = { c={r=0, g=1, b=1}, press=function(_) tm.command("v") end},
+    [tm.B1] = { c={r=0, g=1, b=1}, press=function(_) tm.command("b") end},
+    [tm.B2] = { c={r=0, g=1, b=1}, press=function(_) tm.command("c") end},
+
+    [tm.C1] = { c={r=1, g=1, b=0}, press=function(_) tm.command("h") end},
+    [tm.D1] = { c={r=1, g=1, b=0}, press=function(_) tm.command("l") end},
+
+    [tm.D2] = { c={r=1, g=0, b=1}, press=function(_) tm.command("k") end},
+    [tm.D3] = { c={r=1, g=0, b=1}, press=function(_) tm.command("j") end},
+
+    [tm.B3] = { c={r=0.5, g=1, b=0.5}, press=function(_) tm.command("p") end},
+    [tm.C3] = { c={r=0.5, g=1, b=0.5}, press=function(_) tm.command("n") end},
+
+    [tm.A3] = { c={r=1, g=0, b=0}, press=function(_) tm.exit() end},
 
 }
 

--- a/sdcard/layouts/tmux.lua
+++ b/sdcard/layouts/tmux.lua
@@ -39,9 +39,19 @@ function tm.command(cmd)
     mb.tap(cmd)
 end
 
+function tm.commandShiftLayout(cmd)
+    mb.tap("`")
+    mb.tap(cmd,keybow.LEFT_CTRL)
+    keybow.sleep(50)
+end
+
 function tm.exit()
     keybow.text("exit")
     keybow.tap_enter()
+end
+
+function tm.unshift(_)
+    mb.activate_keymap(tm.keymap.name)
 end
 
 tm.keymap = {
@@ -63,5 +73,22 @@ tm.keymap = {
 
 }
 
+tm.keymap_shifted = {
+    name="tmux-shifted",
+    secondary=true,
+
+    [tm.C1] = { c={r=1, g=1, b=0}, press=function(_) tm.commandShiftLayout("h") end},
+    [tm.D1] = { c={r=1, g=1, b=0}, press=function(_) tm.commandShiftLayout("l") end},
+
+    [tm.D2] = { c={r=1, g=0, b=1}, press=function(_) tm.commandShiftLayout("k") end},
+    [tm.D3] = { c={r=1, g=0, b=1}, press=function(_) tm.commandShiftLayout("j") end},
+
+    [-1] = {release=tm.unshift},
+}
+
+tm.keymap.shift_to = tm.keymap_shifted
+tm.keymap_shifted.shift_to = tm.keymap
+
 mb.register_keymap(tm.keymap)
+mb.register_keymap(tm.keymap_shifted)
 return tm

--- a/sdcard/snippets/mb/morekeys.lua
+++ b/sdcard/snippets/mb/morekeys.lua
@@ -75,6 +75,9 @@ keybow.KPEQUAL = 0x67
 
 keybow.COMPOSE = 0x65
 keybow.POWER = 0x66
+keybow.SUPER = 0xe3
+keybow.SHIFT = 0xe1
+keybow.CTRL = 0x01
 
 keybow.OPEN = 0x74
 keybow.HELP = 0x75


### PR DESCRIPTION
Two new layouts for a numpad and a tmux navigator.

### Numpad

Regular layout
```text
┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
           9       8       7
╔════╗  ╔════╗  ╔════╗  ╔════╗
║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
   0       6       5       4
╔════╗  ╔════╗  ╔════╗  ╔════╗
║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
 enter     3       2       1
```
Shirt layout
```text
┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
           +       -       =
╔════╗  ╔════╗  ╔════╗  ╔════╗
║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
   .       /       %       $
╔════╗  ╔════╗  ╔════╗  ╔════╗
║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
   ,   backspace delete   ESC
```

### Tmux

Regular layout
```text
┌╌╌╌╌┐  ╔════╗  ╔════╗  ╔════╗
┊ 11 ┊  ║  8 ║  ║  5 ║  ║  2 ║
└╌╌╌╌┘  ╚════╝  ╚════╝  ╚════╝
        split v  move l move r
╔════╗  ╔════╗  ╔════╗  ╔════╗
║ 10 ║  ║  7 ║  ║  4 ║  ║  1 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
split h new window      move u
╔════╗  ╔════╗  ╔════╗  ╔════╗
║  9 ║  ║  6 ║  ║  3 ║  ║  0 ║
╚════╝  ╚════╝  ╚════╝  ╚════╝
exit    cycle p cycle n move d
```